### PR TITLE
Fix the problem of dependent but prohibited fields.

### DIFF
--- a/lib/QBit/Application/Model/DBManager/_Utils/Fields.pm
+++ b/lib/QBit/Application/Model/DBManager/_Utils/Fields.pm
@@ -17,8 +17,6 @@ sub new {
     $opt = [grep {$fields->{$_}{'default'}} keys(%$fields)] unless defined($opt);
     $opt = [$opt] if ref($opt) ne 'ARRAY';
 
-    my %opt_fields = map {$_ => 1} @$opt;
-
     foreach (values(%$fields)) {
         $_->{'check_rights'} = [$_->{'check_rights'}]
           if defined($_->{'check_rights'}) && ref($_->{'check_rights'}) ne 'ARRAY';
@@ -37,7 +35,7 @@ sub new {
         $res_fields{$field} = clone($fields->{$field});
     }
 
-    foreach my $field (keys %res_fields) {
+    foreach my $field (keys(%res_fields)) {
         if (exists($fields->{$field}{'depends_on'}) || exists($fields->{$field}{'forced_depends_on'})) {
             foreach
               my $dep_field (@{$fields->{$field}{'depends_on'} || []}, @{$fields->{$field}{'forced_depends_on'} || []})


### PR DESCRIPTION
In the case when the field is prohibited for the role, but it is in
forced_depends_on list, the field will be removed from the sql query, so
another one field which is dependant on the first one will not be able
to be computed.
The problem described above is resolved in the commit.
